### PR TITLE
Agregar módulo de administradores y renombrar contraseña

### DIFF
--- a/src/main/java/com/demo/sistema_gestion_escolar/controller/AdministradorController.java
+++ b/src/main/java/com/demo/sistema_gestion_escolar/controller/AdministradorController.java
@@ -1,0 +1,53 @@
+package com.demo.sistema_gestion_escolar.controller;
+
+import com.demo.sistema_gestion_escolar.model.Administrador;
+import com.demo.sistema_gestion_escolar.service.AdministradorService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/administradores")
+public class AdministradorController {
+
+    @Autowired
+    private AdministradorService administradorService;
+
+    @PostMapping
+    public ResponseEntity<Administrador> crear(@Valid @RequestBody Administrador administrador) {
+        Administrador nuevo = administradorService.crear(administrador);
+        return ResponseEntity.ok(nuevo);
+    }
+
+    @GetMapping
+    public List<Administrador> obtenerTodos() {
+        return administradorService.obtenerTodos();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Administrador> obtenerPorId(@PathVariable Long id) {
+        return administradorService.obtenerPorId(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Administrador> actualizar(@PathVariable Long id, @Valid @RequestBody Administrador administrador) {
+        try {
+            Administrador actualizado = administradorService.actualizar(id, administrador);
+            return ResponseEntity.ok(actualizado);
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        administradorService.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/src/main/java/com/demo/sistema_gestion_escolar/model/Administrador.java
+++ b/src/main/java/com/demo/sistema_gestion_escolar/model/Administrador.java
@@ -10,7 +10,7 @@ public class Administrador extends BaseEntity {
     private String usuario;
 
     @Column(nullable = false, length = 255)
-    private String contraseña;
+    private String contrasena;
 
     @Column(nullable = false, length = 20)
     private String rol; // Ej: ADMIN, SUPERADMIN
@@ -25,12 +25,12 @@ public class Administrador extends BaseEntity {
         this.usuario = usuario;
     }
 
-    public String getContraseña() {
-        return contraseña;
+    public String getContrasena() {
+        return contrasena;
     }
 
-    public void setContraseña(String contraseña) {
-        this.contraseña = contraseña;
+    public void setContrasena(String contrasena) {
+        this.contrasena = contrasena;
     }
 
     public String getRol() {

--- a/src/main/java/com/demo/sistema_gestion_escolar/repository/AdministradorRepository.java
+++ b/src/main/java/com/demo/sistema_gestion_escolar/repository/AdministradorRepository.java
@@ -1,0 +1,13 @@
+package com.demo.sistema_gestion_escolar.repository;
+
+import com.demo.sistema_gestion_escolar.model.Administrador;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdministradorRepository extends JpaRepository<Administrador, Long> {
+    Optional<Administrador> findByUsuario(String usuario);
+}
+

--- a/src/main/java/com/demo/sistema_gestion_escolar/service/AdministradorService.java
+++ b/src/main/java/com/demo/sistema_gestion_escolar/service/AdministradorService.java
@@ -1,0 +1,42 @@
+package com.demo.sistema_gestion_escolar.service;
+
+import com.demo.sistema_gestion_escolar.model.Administrador;
+import com.demo.sistema_gestion_escolar.repository.AdministradorRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class AdministradorService {
+
+    @Autowired
+    private AdministradorRepository administradorRepository;
+
+    public Administrador crear(Administrador administrador) {
+        return administradorRepository.save(administrador);
+    }
+
+    public List<Administrador> obtenerTodos() {
+        return administradorRepository.findAll();
+    }
+
+    public Optional<Administrador> obtenerPorId(Long id) {
+        return administradorRepository.findById(id);
+    }
+
+    public Administrador actualizar(Long id, Administrador datos) {
+        return administradorRepository.findById(id).map(a -> {
+            a.setUsuario(datos.getUsuario());
+            a.setContrasena(datos.getContrasena());
+            a.setRol(datos.getRol());
+            return administradorRepository.save(a);
+        }).orElseThrow(() -> new RuntimeException("Administrador no encontrado"));
+    }
+
+    public void eliminar(Long id) {
+        administradorRepository.deleteById(id);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Reemplaza el campo `contraseña` por `contrasena` en la entidad Administrador
- Añade capas Repository, Service y Controller para gestionar administradores

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae96119e6c832f9d4a10e740c22dfe